### PR TITLE
Use Integer class instead of deprecated Fixnum

### DIFF
--- a/lib/rencoder/encoder.rb
+++ b/lib/rencoder/encoder.rb
@@ -5,7 +5,7 @@ module Rencoder
     def encode(object)
       case object
       when String, Symbol then encode_string(object)
-      when Fixnum then encode_integer(object)
+      when Integer then encode_integer(object)
       when Float then encode_float(object)
       when TrueClass, FalseClass then encode_boolean(object)
       when NilClass then encode_nil(object)
@@ -34,7 +34,7 @@ module Rencoder
         bytes = object.to_s.bytes
 
         if bytes.size >= MAX_INT_LENGTH
-          raise EncodingError, "Unable to serialize Fixnum #{object} due to overflow"
+          raise EncodingError, "Unable to serialize Integer #{object} due to overflow"
         end
 
         [CHR_INT, *bytes, CHR_TERM].pack('C*')


### PR DESCRIPTION
When using this library (I used it indirectly by loading [deluge-rpc](https://github.com/t3hk0d3/deluge-rpc)), a warning is printed:
`.gem/ruby/2.5.0/gems/rencoder-0.1.1/lib/rencoder/encoder.rb:8: warning: constant ::Fixnum is deprecated`

Since I'm not familiar, if I need to change any other files e.g. `.ruby-version` let me know and I'll rebase.