### PR TITLE
Change STR_FIXED and LIST_FIXED to exclude max value

### DIFF
--- a/lib/rencoder.rb
+++ b/lib/rencoder.rb
@@ -40,12 +40,12 @@ module Rencoder
   # Strings with length embedded in typecode.
   STR_FIXED_START = 128
   STR_FIXED_COUNT = 64
-  STR_FIXED = (STR_FIXED_START..STR_FIXED_START + STR_FIXED_COUNT)
+  STR_FIXED = (STR_FIXED_START...STR_FIXED_START + STR_FIXED_COUNT)
 
   # Lists with length embedded in typecode.
   LIST_FIXED_START = STR_FIXED_START+STR_FIXED_COUNT
   LIST_FIXED_COUNT = 64
-  LIST_FIXED = (LIST_FIXED_START..LIST_FIXED_START + LIST_FIXED_COUNT)
+  LIST_FIXED = (LIST_FIXED_START...LIST_FIXED_START + LIST_FIXED_COUNT)
 
   require_relative 'rencoder/encoder'
   require_relative 'rencoder/decoder'

--- a/spec/rencoder/decoder_spec.rb
+++ b/spec/rencoder/decoder_spec.rb
@@ -17,6 +17,14 @@ describe Rencoder::Decoder do
         expect(subject.decode(serialized_string)).to eq('Test')
       end
 
+      it 'decode empty string' do
+        expect(subject.decode(serialized_empty_string)).to eq('')
+      end
+
+      it 'decode maximum embedded-length type string' do
+        expect(subject.decode(serialized_63byte_string)).to eq('a' * 63)
+      end
+
       it 'decode long string' do
         expect(subject.decode(serialized_long_string)).to eq('a' * 100)
       end
@@ -79,8 +87,16 @@ describe Rencoder::Decoder do
     end
 
     describe 'array' do
+      it 'decode empty array' do
+        expect(subject.decode(serialized_empty_array)).to eq([])
+      end
+
       it 'decode small array' do
         expect(subject.decode(serialized_array)).to eq(['Test', 100, 100.0001, nil])
+      end
+
+      it 'decode maximum embedded length type array' do
+        expect(subject.decode(serialized_63_element_array)).to eq(63.times.to_a)
       end
 
       it 'decode big array' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,12 @@ shared_context 'serialization_values' do
   # :test (symbol)
   let(:serialized_symbol) { Base64.decode64('hHRlc3Q=') }
 
+  # ''
+  let(:serialized_empty_string) { Base64.decode64("gA==\n") }
+
+  # maximum embedded-length string type ('a' * 63)
+  let(:serialized_63byte_string) { "\xBF" + 'a' * 63 }
+
   # 'a' * 100
   let(:serialized_long_string) { '100:' + 'a' * 100 }
 
@@ -61,8 +67,16 @@ shared_context 'serialization_values' do
   let(:serialized_nil) { 69.chr }
 
   # Array
+  # []
+  let(:serialized_empty_array) { "\xC0" }
+
   # ["Test", 100, 100.0001, nil]
   let(:serialized_array) { Base64.decode64('xIRUZXN0PmQsQFkAAaNuLrJF') }
+
+  # maximum embedded-length array type (63.times.to_a)
+  let(:serialized_63_element_array) do
+    Base64.decode64("/z4APgE+Aj4DPgQ+BT4GPgc+CD4JPgo+Cz4MPg0+Dj4PPhA+ET4SPhM+FD4V\nPhY+Fz4YPhk+Gj4bPhw+HT4ePh8+ID4hPiI+Iz4kPiU+Jj4nPig+KT4qPis+\nLD4tPi4+Lz4wPjE+Mj4zPjQ+NT42Pjc+OD45Pjo+Oz48Pj0+Pg==\n")
+  end
 
   # big array (100.times.to_a)
   let(:serialized_big_array) do


### PR DESCRIPTION
Both `STR_FIXED` and `LIST_FIXED` use the two-dot range operator, which includes the max value, however the reference implementation in Python excludes the maximum value from these ranges.

`LIST_FIXED` does not seem to cause any problems by being inclusive, but this does not agree with the reference implementation.

When `STR_FIXED` is inclusive of the max value, `STR_FIXED` and `LIST_FIXED` overlap. This causes empty lists to be typed as a 64-character strings. The result is erroneous output, and likely the parser failing with an error.

This PR changes the two-dot range operator on these to the three-dot range operator for both `LIST_FIXED` and `STR_FIXED`. It also adds a couple of additional specs around this logic.